### PR TITLE
Fixing BTree queries

### DIFF
--- a/src/main/java/com/github/jambodb/storage/btrees/BTree.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTree.java
@@ -106,7 +106,7 @@ public final class BTree<K extends Comparable<K>, V> {
      * Given a key this method will search the tree from top to bottom to find it,
      * if the given key is found this method will read and return its value but if the
      * given key is not found the method will return null.
-     *
+     * <p>
      * IMPORTANT: if the underlying storage returns null for the value of the given key,
      * this method will still return null, hence by using this method along there is
      * no way of determining if a given key does not exist or its value is null.
@@ -117,7 +117,7 @@ public final class BTree<K extends Comparable<K>, V> {
      */
     public V get(K key) throws IOException {
         var result = lookup(key, null);
-        if(result.found) {
+        if (result.found) {
             return result.page.value(result.index);
         }
         return null;
@@ -133,15 +133,14 @@ public final class BTree<K extends Comparable<K>, V> {
     public void put(K key, V value) throws IOException {
         var ancestors = new LinkedList<Node<K, V>>();
         var result = lookup(key, ancestors);
-        if(result.found) {
+        if (result.found) {
             result.page.value(result.index, value);
-        }
-        else {
+        } else {
             insertPlace(result.page, result.index);
             result.page.key(result.index, key);
             result.page.value(result.index, value);
 
-            if(result.page.isFull()) {
+            if (result.page.isFull()) {
                 split(result.page, ancestors);
             }
         }
@@ -156,10 +155,10 @@ public final class BTree<K extends Comparable<K>, V> {
     public void remove(K key) throws IOException {
         var ancestors = new LinkedList<Node<K, V>>();
         var result = lookup(key, ancestors);
-        if(result.found) {
+        if (result.found) {
             deletePlace(result.page, result.index);
 
-            if(result.page.isHalf()) {
+            if (result.page.isHalf()) {
                 fill(result.page, ancestors);
             }
         }
@@ -175,7 +174,7 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException
      */
     public Iterator<BTreeEntry<K, V>> query(K from, K to) throws IOException {
-        if(root.isLeaf() && root.size() == 0) {
+        if (root.isLeaf() && root.size() == 0) {
             return Collections.emptyIterator();
         }
 
@@ -199,7 +198,7 @@ public final class BTree<K extends Comparable<K>, V> {
                 var entry = current;
                 try {
                     current = BTree.this.next(current, ancestors);
-                    if(current != null) {
+                    if (current != null) {
                         var key = current.key();
                         if (to != null && key.compareTo(to) > 0) {
                             current = null;
@@ -222,13 +221,13 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException
      */
     Node<K, V> first(BTreePage<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
-        while(!current.isLeaf()) {
-            if(ancestors != null) {
+        while (!current.isLeaf()) {
+            if (ancestors != null) {
                 ancestors.addFirst(new Node<>(current, 0));
             }
             current = getChildPage(current, 0);
         }
-        if(current.size() > 0) {
+        if (current.size() > 0) {
             return new Node<>(current, 0);
         }
         return null;
@@ -243,13 +242,13 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException
      */
     Node<K, V> last(BTreePage<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
-        while(!current.isLeaf()) {
-            if(ancestors != null) {
+        while (!current.isLeaf()) {
+            if (ancestors != null) {
                 ancestors.addFirst(new Node<>(current, 0));
             }
             current = getChildPage(current, current.size());
         }
-        if(current.size() > 0) {
+        if (current.size() > 0) {
             return new Node<>(current, current.size());
         }
         return null;
@@ -264,21 +263,20 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException
      */
     Node<K, V> next(Node<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
-        if(current.page.isLeaf()) {
-            if(current.index+1 < current.page.size()) {
-                return new Node<>(current.page, current.index+1);
+        if (current.page.isLeaf()) {
+            if (current.index + 1 < current.page.size()) {
+                return new Node<>(current.page, current.index + 1);
             }
-        }
-        else {
-            if(current.index < current.page.size()) {
-                ancestors.addFirst(new Node<>(current.page, current.index+1));
-                return first(getChildPage(current.page, current.index+1), ancestors);
+        } else {
+            if (current.index < current.page.size()) {
+                ancestors.addFirst(new Node<>(current.page, current.index + 1));
+                return first(getChildPage(current.page, current.index + 1), ancestors);
             }
         }
 
-        while(!ancestors.isEmpty()) {
+        while (!ancestors.isEmpty()) {
             var node = ancestors.removeFirst();
-            if(node.index < node.page.size()) {
+            if (node.index < node.page.size()) {
                 return node;
             }
         }
@@ -294,22 +292,21 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException
      */
     Node<K, V> prev(Node<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
-        if(current.page.isLeaf()) {
-            if(current.index-1 >= 0) {
-                return new Node<>(current.page, current.index-1);
+        if (current.page.isLeaf()) {
+            if (current.index - 1 >= 0) {
+                return new Node<>(current.page, current.index - 1);
             }
-        }
-        else {
-            if(current.index >= 0) {
+        } else {
+            if (current.index >= 0) {
                 ancestors.addFirst(current);
                 return last(getChildPage(current.page, current.index), ancestors);
             }
         }
 
-        while(!ancestors.isEmpty()) {
+        while (!ancestors.isEmpty()) {
             var node = ancestors.removeFirst();
-            if(node.index-1 >= 0) {
-                return new Node<>(node.page, node.index-1);
+            if (node.index - 1 >= 0) {
+                return new Node<>(node.page, node.index - 1);
             }
         }
         return null;
@@ -328,11 +325,11 @@ public final class BTree<K extends Comparable<K>, V> {
         var current = root;
         while (!current.isLeaf()) {
             var result = search(current, key);
-            if(result.found) {
+            if (result.found) {
                 return result;
             }
 
-            if(ancestors != null) {
+            if (ancestors != null) {
                 ancestors.addFirst(result);
             }
             current = getChildPage(result.page, result.index);
@@ -344,12 +341,12 @@ public final class BTree<K extends Comparable<K>, V> {
     Node<K, V> lookupFirst(K from, Deque<Node<K, V>> ancestors) throws IOException {
         var result = lookup(from, ancestors);
 
-        if(result.found) {
+        if (result.found) {
             return result;
         }
 
         Node<K, V> current = result;
-        if(current.isOffPage()) {
+        if (current.isOffPage()) {
             current = prev(current, ancestors);
         }
 
@@ -365,7 +362,7 @@ public final class BTree<K extends Comparable<K>, V> {
         ancestors.addAll(prevAncestors);
         current = prev;
         while (current != null) {
-            if(current.greaterThan(from)) {
+            if (current.greaterThan(from)) {
                 return current;
             }
             current = next(current, ancestors);
@@ -382,7 +379,7 @@ public final class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    Result<K, V> search(BTreePage<K,V> page, K key) throws IOException {
+    Result<K, V> search(BTreePage<K, V> page, K key) throws IOException {
         int p = 0;
         int r = page.size() - 1;
 
@@ -390,14 +387,13 @@ public final class BTree<K extends Comparable<K>, V> {
             int q = p + (r - p) / 2;
 
             var currentKey = page.key(q);
-            if(Objects.equals(currentKey, key)) {
+            if (Objects.equals(currentKey, key)) {
                 return new Result<>(page, q, true);
             }
 
-            if(key.compareTo(currentKey) <= 0) {
+            if (key.compareTo(currentKey) <= 0) {
                 r = q - 1;
-            }
-            else {
+            } else {
                 p = q + 1;
             }
         }
@@ -415,10 +411,9 @@ public final class BTree<K extends Comparable<K>, V> {
      */
     void split(BTreePage<K, V> source, Deque<Node<K, V>> ancestors) throws IOException {
         Node<K, V> parent;
-        if(ancestors.isEmpty()) {
+        if (ancestors.isEmpty()) {
             parent = grow();
-        }
-        else {
+        } else {
             parent = ancestors.removeFirst();
         }
 
@@ -427,9 +422,9 @@ public final class BTree<K extends Comparable<K>, V> {
         move(source, target, mid + 1);
         promoteLast(source, parent);
         parent.page.child(parent.index, source.id());
-        parent.page.child(parent.index+1, target.id());
+        parent.page.child(parent.index + 1, target.id());
 
-        if(parent.page.isFull()) {
+        if (parent.page.isFull()) {
             split(parent.page, ancestors);
         }
     }
@@ -442,13 +437,13 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException
      */
     void fill(BTreePage<K, V> target, Deque<Node<K, V>> ancestors) throws IOException {
-        if(ancestors.isEmpty()) {
+        if (ancestors.isEmpty()) {
             shrink();
             return;
         }
 
         var parent = ancestors.removeFirst();
-        if(borrowLeft(parent, target) || borrowRight(parent, target)) {
+        if (borrowLeft(parent, target) || borrowRight(parent, target)) {
             return;
         }
 
@@ -482,7 +477,7 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException if any I/O error occurs while removing the root page or setting the new root page in the pager.
      */
     void shrink() throws IOException {
-        if(root.size() == 0 && !root.isLeaf()) {
+        if (root.size() == 0 && !root.isLeaf()) {
             pager.remove(root.id());
             root = getChildPage(root, 0);
             pager.root(root.id());
@@ -495,17 +490,17 @@ public final class BTree<K extends Comparable<K>, V> {
      * @param parent the parent node for the right rotation, must be the parent of the target page.
      * @param target the target page for the right rotation, the one that will receive the parent element.
      * @return true if the borrow was possible or false if the source page cannot be borrowed from or the
-     *         parent node is invalid.
+     * parent node is invalid.
      * @throws IOException if any I/O exception occurs reading the source page from the pager.
      */
     boolean borrowLeft(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
-        if(parent.index <= 0) {
+        if (parent.index <= 0) {
             return false;
         }
 
-        parent = new Node<>(parent.page, parent.index-1);
+        parent = new Node<>(parent.page, parent.index - 1);
         var source = getChildPage(parent.page, parent.index);
-        if(!source.canBorrow()) {
+        if (!source.canBorrow()) {
             return false;
         }
 
@@ -522,12 +517,12 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException if any I/O exception occurs reading the source page from the pager.
      */
     boolean borrowRight(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
-        if(parent.index >= parent.page.size()) {
+        if (parent.index >= parent.page.size()) {
             return false;
         }
 
-        var source = getChildPage(parent.page, parent.index+1);
-        if(!source.canBorrow()) {
+        var source = getChildPage(parent.page, parent.index + 1);
+        if (!source.canBorrow()) {
             return false;
         }
 
@@ -545,11 +540,11 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException if any I/O error occurs deleting the source page.
      */
     boolean mergeLeft(Node<K, V> parent, BTreePage<K, V> source) throws IOException {
-        if(parent.index <= 0) {
+        if (parent.index <= 0) {
             return false;
         }
 
-        parent = new Node<>(parent.page, parent.index-1);
+        parent = new Node<>(parent.page, parent.index - 1);
         var target = getChildPage(parent.page, parent.index);
         merge(parent, source, target);
         return true;
@@ -564,11 +559,11 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException if any I/O error occurs deleting the source page.
      */
     boolean mergeRight(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
-        if(parent.index >= parent.page.size()) {
+        if (parent.index >= parent.page.size()) {
             return false;
         }
 
-        var source = getChildPage(parent.page, parent.index+1);
+        var source = getChildPage(parent.page, parent.index + 1);
         merge(parent, source, target);
         return true;
     }
@@ -583,9 +578,9 @@ public final class BTree<K extends Comparable<K>, V> {
      * @throws IOException if any I/O error occurs deleting the source page.
      */
     void merge(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) throws IOException {
-        target.size(target.size()+1);
-        target.key(target.size()-1 , parent.page.key(parent.index));
-        target.value(target.size()-1 , parent.page.value(parent.index));
+        target.size(target.size() + 1);
+        target.key(target.size() - 1, parent.page.key(parent.index));
+        target.value(target.size() - 1, parent.page.value(parent.index));
 
         deletePlace(parent.page, parent.index);
         parent.page.child(parent.index, target.id());
@@ -601,21 +596,21 @@ public final class BTree<K extends Comparable<K>, V> {
      * @param source the page holding the elements to move, this should be a non-empty page.
      * @param target the target page to move the elements to, this page can be empty.
      *               if the page is not empty the nodes will be put at the end of this page.
-     * @param index a valid index at the source page signaling the first element that will be moved.
+     * @param index  a valid index at the source page signaling the first element that will be moved.
      */
     void move(BTreePage<K, V> source, BTreePage<K, V> target, int index) {
-        if(index < 0 || index > source.size()) {
+        if (index < 0 || index > source.size()) {
             throw new IndexOutOfBoundsException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, source.id(), source.size()));
         }
         int prevSize = target.size();
         int moveSize = source.size() - index;
         target.size(target.size() + moveSize);
-        for(int i = 0; i <= moveSize; i++) {
-            if(i < moveSize) {
+        for (int i = 0; i <= moveSize; i++) {
+            if (i < moveSize) {
                 target.key(prevSize + i, source.key(index + i));
                 target.value(prevSize + i, source.value(index + i));
             }
-            if(!target.isLeaf()) {
+            if (!target.isLeaf()) {
                 target.child(prevSize + i, source.child(index + i));
             }
         }
@@ -631,13 +626,13 @@ public final class BTree<K extends Comparable<K>, V> {
      * @param parent The parent node where the promoted element will be place.
      */
     void promoteLast(BTreePage<K, V> source, Node<K, V> parent) {
-        if(source.size() <= 0) {
+        if (source.size() <= 0) {
             throw new IllegalArgumentException(String.format("the page %d is empty", source.id()));
         }
         insertPlace(parent.page, parent.index);
-        parent.page.key(parent.index, source.key(source.size()-1));
-        parent.page.value(parent.index, source.value(source.size()-1));
-        source.size(source.size()-1);
+        parent.page.key(parent.index, source.key(source.size() - 1));
+        parent.page.value(parent.index, source.value(source.size() - 1));
+        source.size(source.size() - 1);
     }
 
     /**
@@ -649,16 +644,16 @@ public final class BTree<K extends Comparable<K>, V> {
      * @param target The target page, must be the left child of the parent node.
      */
     void rotateLeft(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) {
-        if(source.size() <= 0) {
+        if (source.size() <= 0) {
             throw new IllegalArgumentException(String.format("the page %d is empty", source.id()));
         }
-        if(parent.index < 0 || parent.index >= parent.page.size()) {
+        if (parent.index < 0 || parent.index >= parent.page.size()) {
             throw new IndexOutOfBoundsException(String.format("index %d is out of bounds with respect to the page %d with size %d", parent.index, parent.page.id(), parent.page.size()));
         }
-        target.size(target.size()+1);
-        target.key(target.size()-1, parent.page.key(parent.index));
-        target.value(target.size()-1, parent.page.value(parent.index));
-        if(!target.isLeaf()) {
+        target.size(target.size() + 1);
+        target.key(target.size() - 1, parent.page.key(parent.index));
+        target.value(target.size() - 1, parent.page.value(parent.index));
+        if (!target.isLeaf()) {
             target.child(target.size(), source.child(0));
         }
 
@@ -676,44 +671,44 @@ public final class BTree<K extends Comparable<K>, V> {
      * @param target The target page, must be the right child of the parent node.
      */
     void rotateRight(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) {
-        if(source.size() <= 0) {
+        if (source.size() <= 0) {
             throw new IllegalArgumentException(String.format("the page %d is empty", source.id()));
         }
-        if(parent.index < 0 || parent.index >= parent.page.size()) {
+        if (parent.index < 0 || parent.index >= parent.page.size()) {
             throw new IndexOutOfBoundsException(String.format("index %d is out of bounds with respect to the page %d with size %d", parent.index, parent.page.id(), parent.page.size()));
         }
         insertPlace(target, 0);
         target.key(0, parent.page.key(parent.index));
         target.value(0, parent.page.value(parent.index));
-        if(!target.isLeaf()) {
+        if (!target.isLeaf()) {
             target.child(0, source.child(source.size()));
         }
 
-        parent.page.key(parent.index, source.key(source.size()-1));
-        parent.page.value(parent.index, source.value(source.size()-1));
-        source.size(source.size()-1);
+        parent.page.key(parent.index, source.key(source.size() - 1));
+        parent.page.value(parent.index, source.value(source.size() - 1));
+        source.size(source.size() - 1);
     }
 
     /**
      * This method inserts an empty spot at the given index by moving
      * every node one step to the right.
      *
-     * @param page The page to insert the place into.
+     * @param page  The page to insert the place into.
      * @param index The index at which the empty spot will be inserted.
      */
     void insertPlace(BTreePage<K, V> page, int index) {
-        if(index < 0 || index > page.size()) {
+        if (index < 0 || index > page.size()) {
             throw new IndexOutOfBoundsException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, page.id(), page.size()));
         }
 
-        page.size(page.size()+1);
-        for(int i = page.size(); i > index; i--) {
-            if(i < page.size()) {
-                page.key(i, page.key(i-1));
-                page.value(i, page.value(i-1));
+        page.size(page.size() + 1);
+        for (int i = page.size(); i > index; i--) {
+            if (i < page.size()) {
+                page.key(i, page.key(i - 1));
+                page.value(i, page.value(i - 1));
             }
-            if(!page.isLeaf()) {
-                page.child(i, page.child(i-1));
+            if (!page.isLeaf()) {
+                page.child(i, page.child(i - 1));
             }
         }
     }
@@ -722,42 +717,42 @@ public final class BTree<K extends Comparable<K>, V> {
      * This method will delete the node at the given index by moving all
      * the remaining values one step left.
      *
-     * @param page The page to delete the node from.
+     * @param page  The page to delete the node from.
      * @param index The index to be deleted from the given page.
      */
     void deletePlace(BTreePage<K, V> page, int index) {
-        if(index < 0 || index >= page.size()) {
+        if (index < 0 || index >= page.size()) {
             throw new IndexOutOfBoundsException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, page.id(), page.size()));
         }
 
-        for(int i = index; i < page.size(); i++) {
-            if(i < page.size() - 1) {
-                page.key(i, page.key(i+1));
-                page.value(i, page.value(i+1));
+        for (int i = index; i < page.size(); i++) {
+            if (i < page.size() - 1) {
+                page.key(i, page.key(i + 1));
+                page.value(i, page.value(i + 1));
             }
-            if(!page.isLeaf()) {
-                page.child(i, page.child(i+1));
+            if (!page.isLeaf()) {
+                page.child(i, page.child(i + 1));
             }
         }
-        page.size(page.size()-1);
+        page.size(page.size() - 1);
     }
 
     /**
      * Gets the child page referenced by the specified node, this method will invoke the underlying pager.page()
      * method to load the child page.
      *
-     * @param page The non-leaf page to get the child id from.
+     * @param page  The non-leaf page to get the child id from.
      * @param index The valid index withing the bounds of page that holds the id of the child page.
      * @return The page object referenced by the parent page at the given index.
-     * @throws IOException thrown by the Pager interface if any I/O errors occur loading the page.
-     * @throws IllegalArgumentException if the page parameter is not a leaf page.
+     * @throws IOException               thrown by the Pager interface if any I/O errors occur loading the page.
+     * @throws IllegalArgumentException  if the page parameter is not a leaf page.
      * @throws IndexOutOfBoundsException if the page parameter is not a leaf page.
      */
-    BTreePage<K,V> getChildPage(BTreePage<K,V> page, int index) throws IOException {
-        if(page.isLeaf()) {
+    BTreePage<K, V> getChildPage(BTreePage<K, V> page, int index) throws IOException {
+        if (page.isLeaf()) {
             throw new IllegalArgumentException("getChildPage called on leaf page.");
         }
-        if(index < 0 || index > page.size()) {
+        if (index < 0 || index > page.size()) {
             throw new IndexOutOfBoundsException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, page.id(), page.size()));
         }
         return pager.page(page.child(index));

--- a/src/main/java/com/github/jambodb/storage/btrees/BTree.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTree.java
@@ -637,8 +637,8 @@ public final class BTree<K extends Comparable<K>, V> {
      * This method inserts an empty spot at the given index by moving
      * every node one step to the right.
      *
-     * @param page
-     * @param index
+     * @param page The page to insert the place into.
+     * @param index The index at which the empty spot will be inserted.
      */
     void insertPlace(BTreePage<K, V> page, int index) {
         page.size(page.size()+1);
@@ -655,12 +655,16 @@ public final class BTree<K extends Comparable<K>, V> {
 
     /**
      * This method will delete the node at the given index by moving all
-     * the nodes to its right one step to the left.
+     * the values from its right one step to the left.
      *
-     * @param page
-     * @param index
+     * @param page The page to delete the node from.
+     * @param index The index to be deleted from the given page.
      */
     void deletePlace(BTreePage<K, V> page, int index) {
+        if(index < 0 || index >= page.size()) {
+            throw new IllegalArgumentException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, page.id(), page.size()));
+        }
+
         for(int i = index; i < page.size(); i++) {
             if(i < page.size() - 1) {
                 page.key(i, page.key(i+1));
@@ -671,17 +675,27 @@ public final class BTree<K extends Comparable<K>, V> {
             }
         }
         page.size(page.size()-1);
+        page.clean();
     }
 
     /**
-     * Gets the child page referenced by the specified node.
+     * Gets the child page referenced by the specified node, this method will invoke the underlying pager.page()
+     * method to load the child page.
      *
-     * @param page
-     * @param index
-     * @return
-     * @throws IOException
+     * @param page The non-leaf page to get the child id from.
+     * @param index The valid index withing the bounds of page that holds the id of the child page.
+     * @return The page object referenced by the parent page at the given index.
+     * @throws IOException thrown by the Pager interface if any I/O errors occur loading the page.
+     * @throws IllegalArgumentException if the page parameter is not a leaf page.
+     * @throws IndexOutOfBoundsException if the page parameter is not a leaf page.
      */
     BTreePage<K,V> getChildPage(BTreePage<K,V> page, int index) throws IOException {
+        if(page.isLeaf()) {
+            throw new IllegalArgumentException("getChildPage called on leaf page.");
+        }
+        if(index < 0 || index > page.size()) {
+            throw new IllegalArgumentException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, page.id(), page.size()));
+        }
         return pager.page(page.child(index));
     }
 }

--- a/src/main/java/com/github/jambodb/storage/btrees/BTree.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTree.java
@@ -3,8 +3,26 @@ package com.github.jambodb.storage.btrees;
 import java.io.IOException;
 import java.util.*;
 
+/**
+ * This class represents a generic BTree implementation, it provides
+ * the basic algorithms involve in reading and writing values to the given
+ * page storage. No assumption is made about the underlying storage, the pages
+ * managed by this structure could be on memory, disk or even the network.
+ * The only requirement is that the pages can be created and the cells can be copied
+ * and moved at will.
+ *
+ * @param <K> The type for the key.
+ * @param <V> The type for the value.
+ */
 public class BTree<K extends Comparable<K>, V> {
 
+    /**
+     * This class holds a reference to a particular point in the tree,
+     * a node (or cell) is located by its page and its index within that page.
+     *
+     * @param <K> The type for the key.
+     * @param <V> The type for the value.
+     */
     private static class Node<K, V> implements BTreeEntry<K, V> {
         BTreePage<K, V> page;
         int index;
@@ -25,6 +43,14 @@ public class BTree<K extends Comparable<K>, V> {
         }
     }
 
+    /**
+     * The result of a lookup operation perform on the tree, this class
+     * holds the last node visited by the lookup method and if the actual key
+     * was found or not.
+     *
+     * @param <K> The type for the key.
+     * @param <V> The type for the value.
+     */
     private static class Result<K, V> extends Node<K, V> {
         boolean found;
 
@@ -34,15 +60,40 @@ public class BTree<K extends Comparable<K>, V> {
         }
     }
 
+    /**
+     * This is the reference to the underlying page storage.
+     */
     private Pager<BTreePage<K, V>> pager;
 
+    /**
+     * A reference to the root page of the tree.
+     */
     private BTreePage<K, V> root;
 
+    /**
+     * The constructor builds a BTree instance for the given page storage.
+     *
+     * @param pager The object responsible for storing the pages managed by this tree.
+     * @throws IOException Thrown by the underlying storage.
+     */
     public BTree(Pager<BTreePage<K, V>> pager) throws IOException {
         this.pager = pager;
         this.root = pager.page(pager.root());
     }
 
+    /**
+     * Given a key this method will search the tree from top to bottom to find it,
+     * if the given key is found this method will read and return its value but if the
+     * given key is not found the method will return null.
+     *
+     * IMPORTANT: if the underlying storage returns null for the value of the given key,
+     * this method will still return null, hence by using this method along there is
+     * no way of determining if a given key does not exist or its value is null.
+     *
+     * @param key The key to look for in the tree.
+     * @return The value associated with the key or null if it does not exist.
+     * @throws IOException Thrown by the underlying storage.
+     */
     public V get(K key) throws IOException {
         var result = lookup(key, null);
         if(result.found) {
@@ -51,6 +102,13 @@ public class BTree<K extends Comparable<K>, V> {
         return null;
     }
 
+    /**
+     * Sets the given key to the given value by inserting or updating it.
+     *
+     * @param key
+     * @param value
+     * @throws IOException
+     */
     public void put(K key, V value) throws IOException {
         var ancestors = new LinkedList<Node<K, V>>();
         var result = lookup(key, ancestors);
@@ -68,6 +126,12 @@ public class BTree<K extends Comparable<K>, V> {
         }
     }
 
+    /**
+     * Removes the given key from the tree if it exists.
+     *
+     * @param key
+     * @throws IOException
+     */
     public void remove(K key) throws IOException {
         var ancestors = new LinkedList<Node<K, V>>();
         var result = lookup(key, ancestors);
@@ -80,6 +144,15 @@ public class BTree<K extends Comparable<K>, V> {
         }
     }
 
+    /**
+     * Returns a range of entries from the given start key (inclusive) to the given
+     * end key (also inclusive)
+     *
+     * @param from
+     * @param to
+     * @return
+     * @throws IOException
+     */
     public Iterator<BTreeEntry<K, V>> query(K from, K to) throws IOException {
         if(root.isLeaf() && root.size() == 0) {
             return Collections.emptyIterator();
@@ -115,6 +188,14 @@ public class BTree<K extends Comparable<K>, V> {
         };
     }
 
+    /**
+     * Gets the first node of the sub-tree rooted at the given current node.
+     *
+     * @param current
+     * @param ancestors
+     * @return
+     * @throws IOException
+     */
     private Node<K, V> first(BTreePage<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
         while(!current.isLeaf()) {
             if(ancestors != null) {
@@ -128,6 +209,14 @@ public class BTree<K extends Comparable<K>, V> {
         return null;
     }
 
+    /**
+     * Gets the last node of the sub-tree rooted at the given current node.
+     *
+     * @param current
+     * @param ancestors
+     * @return
+     * @throws IOException
+     */
     private Node<K, V> last(BTreePage<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
         while(!current.isLeaf()) {
             if(ancestors != null) {
@@ -141,6 +230,14 @@ public class BTree<K extends Comparable<K>, V> {
         return null;
     }
 
+    /**
+     * Returns the next node from the given current node.
+     *
+     * @param current
+     * @param ancestors
+     * @return
+     * @throws IOException
+     */
     private Node<K, V> next(Node<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
         if(current.page.isLeaf()) {
             if(current.index+1 < current.page.size()) {
@@ -163,6 +260,14 @@ public class BTree<K extends Comparable<K>, V> {
         return null;
     }
 
+    /**
+     * Returns the previous node from the given current node.
+     *
+     * @param current
+     * @param ancestors
+     * @return
+     * @throws IOException
+     */
     private Node<K, V> prev(Node<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
         if(current.page.isLeaf()) {
             if(current.index-1 >= 0) {
@@ -185,6 +290,15 @@ public class BTree<K extends Comparable<K>, V> {
         return null;
     }
 
+    /**
+     * Recursively search for the specified key starting at the root of the tree, until either the key is found,
+     * or a leaf node that does not contain the key is reached.
+     *
+     * @param key
+     * @param ancestors
+     * @return
+     * @throws IOException
+     */
     private Result<K, V> lookup(K key, Deque<Node<K, V>> ancestors) throws IOException {
         var current = root;
         while (!current.isLeaf()) {
@@ -202,6 +316,14 @@ public class BTree<K extends Comparable<K>, V> {
         return search(current, key);
     }
 
+    /**
+     * Performs a binary search for the specified key in the given page.
+     *
+     * @param page
+     * @param key
+     * @return
+     * @throws IOException
+     */
     private Result<K, V> search(BTreePage<K,V> page, K key) throws IOException {
         int p = 0;
         int r = page.size() - 1;
@@ -225,6 +347,14 @@ public class BTree<K extends Comparable<K>, V> {
         return new Result<>(page, p, false);
     }
 
+    /**
+     * Splits a page that has become full into two pages by creating a new page and moving half
+     * of the nodes to the new page.
+     *
+     * @param source
+     * @param ancestors
+     * @throws IOException
+     */
     private void split(BTreePage<K, V> source, Deque<Node<K, V>> ancestors) throws IOException {
         Node<K, V> parent;
         if(ancestors.isEmpty()) {
@@ -246,6 +376,13 @@ public class BTree<K extends Comparable<K>, V> {
         }
     }
 
+    /**
+     * Fills a page by borrowing from or merging it with either page to its side.
+     *
+     * @param target
+     * @param ancestors
+     * @throws IOException
+     */
     private void fill(BTreePage<K, V> target, Deque<Node<K, V>> ancestors) throws IOException {
         if(ancestors.isEmpty()) {
             shrink();
@@ -267,6 +404,12 @@ public class BTree<K extends Comparable<K>, V> {
         throw new IllegalStateException("Could not fill the node.");
     }
 
+    /**
+     * Grows the tree by adding a new root page.
+     *
+     * @return
+     * @throws IOException
+     */
     private Node<K, V> grow() throws IOException {
         var newRoot = pager.create(false);
         newRoot.child(0, root.id());
@@ -275,6 +418,11 @@ public class BTree<K extends Comparable<K>, V> {
         return new Node<>(root, 0);
     }
 
+    /**
+     * Shrinks the tree by removing the root page.
+     *
+     * @throws IOException
+     */
     private void shrink() throws IOException {
         if(root.size() == 0 && !root.isLeaf()) {
             pager.remove(root.id());
@@ -283,6 +431,14 @@ public class BTree<K extends Comparable<K>, V> {
         }
     }
 
+    /**
+     * Try to borrow the last node of the page to the left of the target page.
+     *
+     * @param parent
+     * @param target
+     * @return
+     * @throws IOException
+     */
     private boolean borrowLeft(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
         if(parent.index <= 0) {
             return false;
@@ -297,6 +453,14 @@ public class BTree<K extends Comparable<K>, V> {
         return true;
     }
 
+    /**
+     * Try to borrow the first node of the page to the right of the target page.
+     *
+     * @param parent
+     * @param target
+     * @return
+     * @throws IOException
+     */
     private boolean borrowRight(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
         if(parent.index >= parent.page.size()) {
             return false;
@@ -311,6 +475,14 @@ public class BTree<K extends Comparable<K>, V> {
         return true;
     }
 
+    /**
+     * Merges the target page with the page to the left
+     *
+     * @param parent
+     * @param source
+     * @return
+     * @throws IOException
+     */
     private boolean mergeLeft(Node<K, V> parent, BTreePage<K, V> source) throws IOException {
         if(parent.index <= 0) {
             return false;
@@ -322,6 +494,14 @@ public class BTree<K extends Comparable<K>, V> {
         return true;
     }
 
+    /**
+     * Merges the target page with the page to the right.
+     *
+     * @param parent
+     * @param target
+     * @return
+     * @throws IOException
+     */
     private boolean mergeRight(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
         if(parent.index >= parent.page.size()) {
             return false;
@@ -332,6 +512,15 @@ public class BTree<K extends Comparable<K>, V> {
         return true;
     }
 
+    /**
+     * This method merges two pages by moving the parent node along with all the nodes of the source page
+     * to the target page.
+     *
+     * @param parent
+     * @param source
+     * @param target
+     * @throws IOException
+     */
     private void merge(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) throws IOException {
         target.size(target.size()+1);
         target.key(target.size()-1 , parent.page.key(parent.index));
@@ -344,6 +533,13 @@ public class BTree<K extends Comparable<K>, V> {
         pager.remove(source.id());
     }
 
+    /**
+     * Move the given node and all the nodes its right from the source page to the end of the target page.
+     *
+     * @param source
+     * @param index
+     * @param target
+     */
     private void move(BTreePage<K, V> source, int index, BTreePage<K, V> target) {
         int prevSize = target.size();
         int moveSize = source.size() - index;
@@ -360,6 +556,12 @@ public class BTree<K extends Comparable<K>, V> {
         source.size(source.size() - moveSize);
     }
 
+    /**
+     * Promotes the last node of the source page into the parent node.
+     *
+     * @param source
+     * @param parent
+     */
     private void promoteLast(BTreePage<K, V> source, Node<K, V> parent) {
         insertPlace(parent.page, parent.index);
         parent.page.key(parent.index, source.key(source.size()-1));
@@ -367,6 +569,14 @@ public class BTree<K extends Comparable<K>, V> {
         source.size(source.size()-1);
     }
 
+    /**
+     * Performs a left rotation by inserting the parent node at the end of the target page
+     * and then moving the first node of the source page to the parent node.
+     *
+     * @param parent
+     * @param source
+     * @param target
+     */
     private void rotateLeft(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) {
         target.size(target.size()+1);
         target.key(target.size()-1, parent.page.key(parent.index));
@@ -380,6 +590,14 @@ public class BTree<K extends Comparable<K>, V> {
         deletePlace(source, 0);
     }
 
+    /**
+     * Performs a right rotation by inserting the parent node at the beginning of the target page
+     * and then moving the last node of the source page to the parent node.
+     *
+     * @param parent
+     * @param source
+     * @param target
+     */
     private void rotateRight(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) {
         insertPlace(target, 0);
         target.key(0, parent.page.key(parent.index));
@@ -391,6 +609,13 @@ public class BTree<K extends Comparable<K>, V> {
         source.size(source.size()-1);
     }
 
+    /**
+     * This method inserts an empty spot at the given index by moving
+     * every node one step to the right.
+     *
+     * @param page
+     * @param index
+     */
     private void insertPlace(BTreePage<K, V> page, int index) {
         page.size(page.size()+1);
         for(int i = page.size(); i > index; i--) {
@@ -404,6 +629,13 @@ public class BTree<K extends Comparable<K>, V> {
         }
     }
 
+    /**
+     * This method will delete the node at the given index by moving all
+     * the nodes to its right one step to the left.
+     *
+     * @param page
+     * @param index
+     */
     private void deletePlace(BTreePage<K, V> page, int index) {
         for(int i = index; i < page.size(); i++) {
             if(i < page.size() - 1) {
@@ -417,6 +649,14 @@ public class BTree<K extends Comparable<K>, V> {
         page.size(page.size()-1);
     }
 
+    /**
+     * Gets the child page referenced by the specified node.
+     *
+     * @param page
+     * @param index
+     * @return
+     * @throws IOException
+     */
     private BTreePage<K,V> getChildPage(BTreePage<K,V> page, int index) throws IOException {
         return pager.page(page.child(index));
     }

--- a/src/main/java/com/github/jambodb/storage/btrees/BTree.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTree.java
@@ -14,7 +14,7 @@ import java.util.*;
  * @param <K> The type for the key.
  * @param <V> The type for the value.
  */
-public class BTree<K extends Comparable<K>, V> {
+public final class BTree<K extends Comparable<K>, V> {
 
     /**
      * This class holds a reference to a particular point in the tree,
@@ -23,7 +23,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param <K> The type for the key.
      * @param <V> The type for the value.
      */
-    private static class Node<K, V> implements BTreeEntry<K, V> {
+    static class Node<K, V> implements BTreeEntry<K, V> {
         BTreePage<K, V> page;
         int index;
 
@@ -56,7 +56,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param <K> The type for the key.
      * @param <V> The type for the value.
      */
-    private static class Result<K, V> extends Node<K, V> {
+    static class Result<K, V> extends Node<K, V> {
         boolean found;
 
         public Result(BTreePage<K, V> page, int index, boolean found) {
@@ -68,12 +68,12 @@ public class BTree<K extends Comparable<K>, V> {
     /**
      * This is the reference to the underlying page storage.
      */
-    private Pager<BTreePage<K, V>> pager;
+    Pager<BTreePage<K, V>> pager;
 
     /**
      * A reference to the root page of the tree.
      */
-    private BTreePage<K, V> root;
+    BTreePage<K, V> root;
 
     /**
      * The constructor builds a BTree instance for the given page storage.
@@ -201,7 +201,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private Node<K, V> first(BTreePage<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
+    Node<K, V> first(BTreePage<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
         while(!current.isLeaf()) {
             if(ancestors != null) {
                 ancestors.addFirst(new Node<>(current, 0));
@@ -222,7 +222,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private Node<K, V> last(BTreePage<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
+    Node<K, V> last(BTreePage<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
         while(!current.isLeaf()) {
             if(ancestors != null) {
                 ancestors.addFirst(new Node<>(current, 0));
@@ -243,7 +243,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private Node<K, V> next(Node<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
+    Node<K, V> next(Node<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
         if(current.page.isLeaf()) {
             if(current.index+1 < current.page.size()) {
                 return new Node<>(current.page, current.index+1);
@@ -273,7 +273,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private Node<K, V> prev(Node<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
+    Node<K, V> prev(Node<K, V> current, Deque<Node<K, V>> ancestors) throws IOException {
         if(current.page.isLeaf()) {
             if(current.index-1 >= 0) {
                 return new Node<>(current.page, current.index-1);
@@ -304,7 +304,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private Result<K, V> lookup(K key, Deque<Node<K, V>> ancestors) throws IOException {
+    Result<K, V> lookup(K key, Deque<Node<K, V>> ancestors) throws IOException {
         var current = root;
         while (!current.isLeaf()) {
             var result = search(current, key);
@@ -321,7 +321,7 @@ public class BTree<K extends Comparable<K>, V> {
         return search(current, key);
     }
 
-    private Node<K, V> lookupFirst(K key, Deque<Node<K, V>> ancestors) throws IOException {
+    Node<K, V> lookupFirst(K key, Deque<Node<K, V>> ancestors) throws IOException {
         var result = lookup(key, ancestors);
 
         if(!result.found) {
@@ -348,7 +348,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private Result<K, V> search(BTreePage<K,V> page, K key) throws IOException {
+    Result<K, V> search(BTreePage<K,V> page, K key) throws IOException {
         int p = 0;
         int r = page.size() - 1;
 
@@ -379,7 +379,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param ancestors
      * @throws IOException
      */
-    private void split(BTreePage<K, V> source, Deque<Node<K, V>> ancestors) throws IOException {
+    void split(BTreePage<K, V> source, Deque<Node<K, V>> ancestors) throws IOException {
         Node<K, V> parent;
         if(ancestors.isEmpty()) {
             parent = grow();
@@ -407,7 +407,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param ancestors
      * @throws IOException
      */
-    private void fill(BTreePage<K, V> target, Deque<Node<K, V>> ancestors) throws IOException {
+    void fill(BTreePage<K, V> target, Deque<Node<K, V>> ancestors) throws IOException {
         if(ancestors.isEmpty()) {
             shrink();
             return;
@@ -434,7 +434,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private Node<K, V> grow() throws IOException {
+    Node<K, V> grow() throws IOException {
         var newRoot = pager.create(false);
         newRoot.child(0, root.id());
         root = newRoot;
@@ -447,7 +447,7 @@ public class BTree<K extends Comparable<K>, V> {
      *
      * @throws IOException
      */
-    private void shrink() throws IOException {
+    void shrink() throws IOException {
         if(root.size() == 0 && !root.isLeaf()) {
             pager.remove(root.id());
             root = getChildPage(root, 0);
@@ -463,7 +463,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private boolean borrowLeft(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
+    boolean borrowLeft(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
         if(parent.index <= 0) {
             return false;
         }
@@ -485,7 +485,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private boolean borrowRight(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
+    boolean borrowRight(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
         if(parent.index >= parent.page.size()) {
             return false;
         }
@@ -507,7 +507,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private boolean mergeLeft(Node<K, V> parent, BTreePage<K, V> source) throws IOException {
+    boolean mergeLeft(Node<K, V> parent, BTreePage<K, V> source) throws IOException {
         if(parent.index <= 0) {
             return false;
         }
@@ -526,7 +526,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private boolean mergeRight(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
+    boolean mergeRight(Node<K, V> parent, BTreePage<K, V> target) throws IOException {
         if(parent.index >= parent.page.size()) {
             return false;
         }
@@ -545,7 +545,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param target
      * @throws IOException
      */
-    private void merge(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) throws IOException {
+    void merge(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) throws IOException {
         target.size(target.size()+1);
         target.key(target.size()-1 , parent.page.key(parent.index));
         target.value(target.size()-1 , parent.page.value(parent.index));
@@ -564,7 +564,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param index
      * @param target
      */
-    private void move(BTreePage<K, V> source, int index, BTreePage<K, V> target) {
+    void move(BTreePage<K, V> source, int index, BTreePage<K, V> target) {
         int prevSize = target.size();
         int moveSize = source.size() - index;
         target.size(target.size() + moveSize);
@@ -586,7 +586,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param source
      * @param parent
      */
-    private void promoteLast(BTreePage<K, V> source, Node<K, V> parent) {
+    void promoteLast(BTreePage<K, V> source, Node<K, V> parent) {
         insertPlace(parent.page, parent.index);
         parent.page.key(parent.index, source.key(source.size()-1));
         parent.page.value(parent.index, source.value(source.size()-1));
@@ -601,7 +601,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param source
      * @param target
      */
-    private void rotateLeft(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) {
+    void rotateLeft(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) {
         target.size(target.size()+1);
         target.key(target.size()-1, parent.page.key(parent.index));
         target.value(target.size()-1, parent.page.value(parent.index));
@@ -622,7 +622,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param source
      * @param target
      */
-    private void rotateRight(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) {
+    void rotateRight(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) {
         insertPlace(target, 0);
         target.key(0, parent.page.key(parent.index));
         target.value(0, parent.page.value(parent.index));
@@ -640,7 +640,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param page
      * @param index
      */
-    private void insertPlace(BTreePage<K, V> page, int index) {
+    void insertPlace(BTreePage<K, V> page, int index) {
         page.size(page.size()+1);
         for(int i = page.size(); i > index; i--) {
             if(i < page.size()) {
@@ -660,7 +660,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @param page
      * @param index
      */
-    private void deletePlace(BTreePage<K, V> page, int index) {
+    void deletePlace(BTreePage<K, V> page, int index) {
         for(int i = index; i < page.size(); i++) {
             if(i < page.size() - 1) {
                 page.key(i, page.key(i+1));
@@ -681,7 +681,7 @@ public class BTree<K extends Comparable<K>, V> {
      * @return
      * @throws IOException
      */
-    private BTreePage<K,V> getChildPage(BTreePage<K,V> page, int index) throws IOException {
+    BTreePage<K,V> getChildPage(BTreePage<K,V> page, int index) throws IOException {
         return pager.page(page.child(index));
     }
 }

--- a/src/main/java/com/github/jambodb/storage/btrees/BTree.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTree.java
@@ -41,6 +41,11 @@ public class BTree<K extends Comparable<K>, V> {
         public V value() {
             return page.value(index);
         }
+
+        @Override
+        public String toString() {
+            return String.format("%s=%s", key(), value());
+        }
     }
 
     /**
@@ -176,7 +181,7 @@ public class BTree<K extends Comparable<K>, V> {
                     current = BTree.this.next(current, ancestors);
                     if(current != null) {
                         var key = current.key();
-                        if (key.compareTo(to) > 0) {
+                        if (to != null && key.compareTo(to) > 0) {
                             current = null;
                         }
                     }
@@ -307,10 +312,10 @@ public class BTree<K extends Comparable<K>, V> {
                 return result;
             }
 
-            if(ancestors != null) {
+            current = getChildPage(result.page, result.index);
+            if(ancestors != null && !current.isLeaf()) {
                 ancestors.addFirst(result);
             }
-            current = getChildPage(result.page, result.index);
         }
 
         return search(current, key);
@@ -319,7 +324,16 @@ public class BTree<K extends Comparable<K>, V> {
     private Node<K, V> lookupFirst(K key, Deque<Node<K, V>> ancestors) throws IOException {
         var result = lookup(key, ancestors);
 
-        if(!result.found && result.key() == null) {
+        if(!result.found) {
+            var prev = prev(result, ancestors);
+            if(prev != null && prev.key().compareTo(key) >= 0) {
+                return prev;
+            }
+
+            if(result.key() != null && result.key().compareTo(key) >= 0) {
+                return result;
+            }
+
             return next(result, ancestors);
         }
 

--- a/src/main/java/com/github/jambodb/storage/btrees/BTree.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTree.java
@@ -538,12 +538,12 @@ public final class BTree<K extends Comparable<K>, V> {
 
     /**
      * This method merges two pages by moving the parent node along with all the nodes of the source page
-     * to the target page.
+     * to the target page. the method also deletes the source page from the pager.
      *
-     * @param parent
-     * @param source
-     * @param target
-     * @throws IOException
+     * @param parent the parent node of the target page.
+     * @param source the page to the right of the parent node.
+     * @param target the page to the left of the parent node.
+     * @throws IOException if any I/O error occurs deleting the source page.
      */
     void merge(Node<K, V> parent, BTreePage<K, V> source, BTreePage<K, V> target) throws IOException {
         target.size(target.size()+1);

--- a/src/main/java/com/github/jambodb/storage/btrees/BTree.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTree.java
@@ -159,7 +159,7 @@ public class BTree<K extends Comparable<K>, V> {
         }
 
         final Deque<Node<K, V>> ancestors = new LinkedList<>();
-        final Node<K, V> fromNode = from == null ? first(root, ancestors) : lookup(from, ancestors);
+        final Node<K, V> fromNode = from == null ? first(root, ancestors) : lookupFirst(from, ancestors);
 
         return new Iterator<>() {
             Node<K, V> current = fromNode;
@@ -314,6 +314,16 @@ public class BTree<K extends Comparable<K>, V> {
         }
 
         return search(current, key);
+    }
+
+    private Node<K, V> lookupFirst(K key, Deque<Node<K, V>> ancestors) throws IOException {
+        var result = lookup(key, ancestors);
+
+        if(!result.found && result.key() == null) {
+            return next(result, ancestors);
+        }
+
+        return result;
     }
 
     /**

--- a/src/main/java/com/github/jambodb/storage/btrees/BTree.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTree.java
@@ -662,7 +662,7 @@ public final class BTree<K extends Comparable<K>, V> {
      */
     void deletePlace(BTreePage<K, V> page, int index) {
         if(index < 0 || index >= page.size()) {
-            throw new IllegalArgumentException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, page.id(), page.size()));
+            throw new IndexOutOfBoundsException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, page.id(), page.size()));
         }
 
         for(int i = index; i < page.size(); i++) {
@@ -694,7 +694,7 @@ public final class BTree<K extends Comparable<K>, V> {
             throw new IllegalArgumentException("getChildPage called on leaf page.");
         }
         if(index < 0 || index > page.size()) {
-            throw new IllegalArgumentException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, page.id(), page.size()));
+            throw new IndexOutOfBoundsException(String.format("index %d is out of bounds with respect to the page %d with size %d", index, page.id(), page.size()));
         }
         return pager.page(page.child(index));
     }

--- a/src/main/java/com/github/jambodb/storage/btrees/BTreePage.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTreePage.java
@@ -7,8 +7,6 @@ public interface BTreePage<K, V> {
 
     void size(int size);
 
-    void clean();
-
     boolean isLeaf();
 
     boolean isFull();

--- a/src/main/java/com/github/jambodb/storage/btrees/BTreePage.java
+++ b/src/main/java/com/github/jambodb/storage/btrees/BTreePage.java
@@ -7,6 +7,8 @@ public interface BTreePage<K, V> {
 
     void size(int size);
 
+    void clean();
+
     boolean isLeaf();
 
     boolean isFull();

--- a/src/test/java/com/github/jambodb/storage/blocks/FileBlockStorageTest.java
+++ b/src/test/java/com/github/jambodb/storage/blocks/FileBlockStorageTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.util.Random;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeFunctionalTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeFunctionalTest.java
@@ -2,7 +2,6 @@ package com.github.jambodb.storage.btrees;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import java.io.IOException;
 import java.util.*;
@@ -10,8 +9,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-public class BTreeTest {
-    public static final Logger LOG = Logger.getLogger(BTreeTest.class.getName());
+public class BTreeFunctionalTest {
+    public static final Logger LOG = Logger.getLogger(BTreeFunctionalTest.class.getName());
 
     @TestFactory
     public Collection<DynamicTest> testBTree() throws IOException {
@@ -20,17 +19,17 @@ public class BTreeTest {
             final int maxDegree = md;
             for(int i = 0; i < 20; i++) {
                 final int size = i;
-                lst.add(DynamicTest.dynamicTest("testing btree md=" + maxDegree + " size=" + size, () -> testBTreeOperations(maxDegree, size)));
+                lst.add(DynamicTest.dynamicTest("testing btree md=" + maxDegree + " size=" + size, () -> testBTree(maxDegree, size)));
             }
             for(int i = 1000; i < 10000; i+=1000) {
                 final int size = i;
-                lst.add(DynamicTest.dynamicTest("testing btree md=" + maxDegree + " size=" + size, () -> testBTreeOperations(maxDegree, size)));
+                lst.add(DynamicTest.dynamicTest("testing btree md=" + maxDegree + " size=" + size, () -> testBTree(maxDegree, size)));
             }
         }
         return lst;
     }
 
-    private void testBTreeOperations(int md, int size) throws IOException {
+    private void testBTree(int md, int size) throws IOException {
         var stiTree = new TreeMap<String, Integer>();
         var itsTree = new TreeMap<Integer, String>();
 
@@ -92,41 +91,6 @@ public class BTreeTest {
                     .toArray();
         }
         Assertions.assertArrayEquals(expected, current, Arrays.toString(expected) + " => " + Arrays.toString(current));
-    }
-
-    @Test
-    public void testBTreeRange() throws IOException {
-        var btree = new BTree<>(new MockPager<String, Integer>(6));
-
-        btree.put("7", 1);
-        btree.put("b", 2);
-
-        var query = btree.query("a", "z");
-        Assertions.assertEquals(1, count(query));
-
-        query = btree.query("a", "z");
-        Assertions.assertEquals("b", query.next().key());
-        Assertions.assertEquals(0, count(query));
-    }
-
-    @Test
-    public void testBTreeRangeComplex() throws IOException {
-        var btree = new BTree<>(new MockPager<String, Integer>(6));
-
-        btree.put("0a", 1);
-        btree.put("9a", 2);
-        btree.put("aa", 3);
-        btree.put("zz", 4);
-
-        var tree = new TreeMap<String, Integer>();
-        tree.put("0a", 1);
-        tree.put("9a", 2);
-        tree.put("aa", 3);
-        tree.put("zz", 4);
-
-        var subMap = tree.subMap("a", true, "z", true);
-        var query = btree.query("a", "z");
-        Assertions.assertEquals(subMap.size(), count(query));
     }
 
     private int count(Iterator<?> query) {

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeFunctionalTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeFunctionalTest.java
@@ -17,7 +17,7 @@ public class BTreeFunctionalTest {
         List<DynamicTest> lst = new ArrayList<>();
         for(int md = 3; md < 100; md+=3) {
             final int maxDegree = md;
-            for(int i = 0; i < 20; i++) {
+            for(int i = 4; i < 20; i++) {
                 final int size = i;
                 lst.add(DynamicTest.dynamicTest("testing btree md=" + maxDegree + " size=" + size, () -> testBTree(maxDegree, size)));
             }
@@ -30,13 +30,13 @@ public class BTreeFunctionalTest {
     }
 
     private void testBTree(int md, int size) throws IOException {
-        var stiTree = new TreeMap<String, Integer>();
-        var itsTree = new TreeMap<Integer, String>();
+        var expectedStiTree = new TreeMap<String, Integer>();
+        var expectedItsTree = new TreeMap<Integer, String>();
 
         var strToInt = new BTree<>(new MockPager<String, Integer>(md));
         var intToStr = new BTree<>(new MockPager<Integer, String>(md));
         for(int i = 0; i < size; i++) {
-            var str = UUID.randomUUID().toString().substring(0, 8);
+            var str = "k" + i;//UUID.randomUUID().toString().substring(0, 8);
 
             Assertions.assertNull(intToStr.get(i));
             Assertions.assertNull(strToInt.get(str));
@@ -59,17 +59,17 @@ public class BTreeFunctionalTest {
             Assertions.assertEquals(str, intToStr.get(i));
             Assertions.assertEquals(i, strToInt.get(str));
 
-            stiTree.put(str, strToInt.get(str));
-            itsTree.put(i, intToStr.get(i));
+            expectedStiTree.put(str, strToInt.get(str));
+            expectedItsTree.put(i, intToStr.get(i));
         }
 
-        assertEqualTrees(itsTree, intToStr, null, null);
-        assertEqualTrees(itsTree.subMap(0, true, 5, true), intToStr, 0, 5);
-        assertEqualTrees(itsTree.subMap(6, true, 9, true), intToStr, 6, 9);
+        assertEqualTrees(expectedItsTree, intToStr, null, null);
+        assertEqualTrees(expectedItsTree.subMap(0, true, 5, true), intToStr, 0, 5);
+        assertEqualTrees(expectedItsTree.subMap(6, true, 9, true), intToStr, 6, 9);
 
-        assertEqualTrees(stiTree, strToInt, null, null);
-        assertEqualTrees(stiTree.subMap("a", true, "z", true), strToInt, "a", "z");
-        assertEqualTrees(stiTree.subMap("0", true, "9", true), strToInt, "0", "9");
+        assertEqualTrees(expectedStiTree, strToInt, null, null);
+        assertEqualTrees(expectedStiTree.subMap("a", true, "z", true), strToInt, "a", "z");
+        assertEqualTrees(expectedStiTree.subMap("0", true, "9", true), strToInt, "0", "9");
     }
 
     private <K extends Comparable<K>, V> void assertEqualTrees(NavigableMap<K, V> tree, BTree<K, V> btree, K from, K to) throws IOException {

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeFunctionalTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeFunctionalTest.java
@@ -3,6 +3,7 @@ package com.github.jambodb.storage.btrees;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.logging.Level;
@@ -15,13 +16,13 @@ public class BTreeFunctionalTest {
     @TestFactory
     public Collection<DynamicTest> testBTree() throws IOException {
         List<DynamicTest> lst = new ArrayList<>();
-        for(int md = 3; md < 100; md+=3) {
+        for (int md = 3; md < 100; md += 3) {
             final int maxDegree = md;
-            for(int i = 4; i < 20; i++) {
+            for (int i = 4; i < 20; i++) {
                 final int size = i;
                 lst.add(DynamicTest.dynamicTest("testing btree md=" + maxDegree + " size=" + size, () -> testBTree(maxDegree, size)));
             }
-            for(int i = 1000; i < 10000; i+=1000) {
+            for (int i = 1000; i < 10000; i += 1000) {
                 final int size = i;
                 lst.add(DynamicTest.dynamicTest("testing btree md=" + maxDegree + " size=" + size, () -> testBTree(maxDegree, size)));
             }
@@ -36,21 +37,21 @@ public class BTreeFunctionalTest {
         var strToInt = new BTree<>(new MockPager<String, Integer>(md));
         var intToStr = new BTree<>(new MockPager<Integer, String>(md));
 
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             var str = UUID.randomUUID().toString().substring(0, 8);
 
             expectedStiTree.put(str, i);
             expectedItsTree.put(i, str);
         }
 
-        var strQueries = Arrays.asList(new String[][] {
-                { "a", "z" },
-                { "0", "9" }
+        var strQueries = Arrays.asList(new String[][]{
+                {"a", "z"},
+                {"0", "9"}
         });
 
-        var intQueries = Arrays.asList(new Integer[][] {
-                { 0, 5 },
-                { 6, 9 }
+        var intQueries = Arrays.asList(new Integer[][]{
+                {0, 5},
+                {6, 9}
         });
 
         testBTree(expectedStiTree, strToInt, strQueries);
@@ -58,25 +59,25 @@ public class BTreeFunctionalTest {
     }
 
     private <K extends Comparable<K>, V> void testBTree(TreeMap<K, V> tree, BTree<K, V> bTree, List<K[]> queries) throws IOException {
-        for(var entry : tree.entrySet()) {
+        for (var entry : tree.entrySet()) {
             bTree.put(entry.getKey(), entry.getValue());
             Assertions.assertEquals(entry.getValue(), bTree.get(entry.getKey()));
         }
 
-        for(var entry : tree.entrySet()) {
+        for (var entry : tree.entrySet()) {
             Assertions.assertEquals(entry.getValue(), bTree.get(entry.getKey()));
         }
 
-        for(var key : tree.keySet()) {
+        for (var key : tree.keySet()) {
             bTree.remove(key);
             Assertions.assertNull(bTree.get(key));
         }
 
-        for(var key : tree.keySet()) {
+        for (var key : tree.keySet()) {
             Assertions.assertNull(bTree.get(key));
         }
 
-        for(var entry : tree.entrySet()) {
+        for (var entry : tree.entrySet()) {
             bTree.put(entry.getKey(), entry.getValue());
             Assertions.assertEquals(entry.getValue(), bTree.get(entry.getKey()));
         }
@@ -98,8 +99,8 @@ public class BTreeFunctionalTest {
                 .toArray();
 
         // debug
-        if(expected.length != current.length) {
-            LOG.log(Level.INFO,"{0} -> {1}", new Object[] { Arrays.toString(expected), Arrays.toString(current) });
+        if (expected.length != current.length) {
+            LOG.log(Level.INFO, "{0} -> {1}", new Object[]{Arrays.toString(expected), Arrays.toString(current)});
             current = toList(btree.query(from, to))
                     .stream()
                     .map(BTreeEntry::key)

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeTest.java
@@ -59,9 +59,27 @@ public class BTreeTest {
             intToStr.put(i, intToStr.get(i));
         }
 
-        var it = strToInt.query("a", "z");
-        while (it.hasNext()) {
-            System.out.println(it.next().value());
+        var bTreeIt = strToInt.query("a", "z");
+        int count = 0;
+        while (bTreeIt.hasNext()) {
+            bTreeIt.next();
+            count++;
+        }
+        bTreeIt = strToInt.query("a", "z");
+        var map = strToIntTree.subMap("a", true, "z", true);
+
+        Assertions.assertEquals(map.size(), count);
+
+        var treeIt = map.entrySet().iterator();
+        while (bTreeIt.hasNext()) {
+            Assertions.assertTrue(treeIt.hasNext());
+
+            var expected = treeIt.next();
+            var current = bTreeIt.next();
+
+            System.out.println(expected.getKey() + " - " + current.key());
+            Assertions.assertEquals(expected.getKey(), current.key());
+            Assertions.assertEquals(expected.getValue(), current.value());
         }
     }
 }

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeTest.java
@@ -6,10 +6,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import java.io.IOException;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 public class BTreeTest {
+    public static final Logger LOG = Logger.getLogger(BTreeTest.class.getName());
+
     @TestFactory
     public Collection<DynamicTest> testBTree() throws IOException {
         List<DynamicTest> lst = new ArrayList<>();
@@ -61,20 +64,33 @@ public class BTreeTest {
             itsTree.put(i, intToStr.get(i));
         }
 
-        assertEqualTrees(stiTree, strToInt.query(null, null));
-        assertEqualTrees(stiTree.subMap("a", true, "z", true), strToInt.query("a", "z"));
-        assertEqualTrees(stiTree.subMap("0", true, "9", true), strToInt.query("0", "9"));
+        assertEqualTrees(itsTree, intToStr, null, null);
+        assertEqualTrees(itsTree.subMap(0, true, 5, true), intToStr, 0, 5);
+        assertEqualTrees(itsTree.subMap(6, true, 9, true), intToStr, 6, 9);
+
+        assertEqualTrees(stiTree, strToInt, null, null);
+        assertEqualTrees(stiTree.subMap("a", true, "z", true), strToInt, "a", "z");
+        assertEqualTrees(stiTree.subMap("0", true, "9", true), strToInt, "0", "9");
     }
 
-    private void assertEqualTrees(NavigableMap<String, Integer> tree, Iterator<BTreeEntry<String, Integer>> query) {
+    private <K extends Comparable<K>, V> void assertEqualTrees(NavigableMap<K, V> tree, BTree<K, V> btree, K from, K to) throws IOException {
         var expected = tree
                 .keySet()
                 .toArray();
-        var current = toList(query)
+        var current = toList(btree.query(from, to))
                 .stream()
                 .map(BTreeEntry::key)
                 .collect(Collectors.toList())
                 .toArray();
+
+        if(expected.length != current.length) {
+            LOG.log(Level.INFO,"{0} -> {1}", new Object[] { Arrays.toString(expected), Arrays.toString(current) });
+            current = toList(btree.query(from, to))
+                    .stream()
+                    .map(BTreeEntry::key)
+                    .collect(Collectors.toList())
+                    .toArray();
+        }
         Assertions.assertArrayEquals(expected, current, Arrays.toString(expected) + " => " + Arrays.toString(current));
     }
 

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
@@ -1,0 +1,4 @@
+package com.github.jambodb.storage.btrees;
+
+public class BTreeUnitTest {
+}

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
@@ -10,16 +10,97 @@ public class BTreeUnitTest {
     private Random random = new Random();
 
     @Test
-    public void testInsertPlace() throws IOException {
-        Pager<BTreePage<String, Integer>> pager = new MockPager<>(26);
+    public void testPromoteLast() throws IOException {
+        MockPager<String, Integer> pager = new MockPager<>(3);
         BTree<String, Integer> btree = new BTree<>(pager);
 
+        var parent = pager.create(false);
+        var source = pager.create(false);
+
+        parent.size(1);
+        parent.key(0, "parent");
+        parent.value(0, 1);
+        parent.child(0, source.id());
+        parent.child(1, 10);
+        source.size(1);
+        source.key(0, "source");
+        source.value(0, 2);
+        source.child(0, 20);
+        source.child(1, 30);
+
+        btree.promoteLast(source, new BTree.Node<>(parent, 0));
+        assertEquals(2, parent.size());
+        assertEquals("source", parent.key(0));
+        assertEquals(2, parent.value(0));
+        assertEquals("parent", parent.key(1));
+        assertEquals(1, parent.value(1));
+        assertEquals(source.id(), parent.child(1));
+        assertEquals(10, parent.child(2));
+        assertEquals(0, source.size());
+    }
+
+    @Test
+    public void testRotations() throws IOException {
+        MockPager<String, Integer> pager = new MockPager<>(3);
+        BTree<String, Integer> btree = new BTree<>(pager);
+
+        var parent = pager.create(false);
+        var source = pager.create(false);
+        var target = pager.create(false);
+
+        parent.size(1);
+        parent.key(0, "parent");
+        parent.value(0, 1);
+        parent.child(0, source.id());
+        parent.child(1, target.id());
+        source.size(1);
+        source.key(0, "source");
+        source.value(0, 2);
+        source.child(0, 10);
+        source.child(1, 20);
+        target.size(0);
+        target.child(0, 30);
+
+        btree.rotateRight(new BTree.Node<>(parent, 0), source, target);
+        assertEquals(1, parent.size());
+        assertEquals("source", parent.key(0));
+        assertEquals(2, parent.value(0));
+        assertEquals(source.id(), parent.child(0));
+        assertEquals(target.id(), parent.child(1));
+        assertEquals(0, source.size());
+        assertEquals(10, source.child(0));
+        assertEquals(1, target.size());
+        assertEquals("parent", target.key(0));
+        assertEquals(1, target.value(0));
+        assertEquals(20, target.child(0));
+        assertEquals(30, target.child(1));
+
+        btree.rotateLeft(new BTree.Node<>(parent, 0), target, source);
+        assertEquals(1, parent.size());
+        assertEquals("parent", parent.key(0));
+        assertEquals(1, parent.value(0));
+        assertEquals(source.id(), parent.child(0));
+        assertEquals(target.id(), parent.child(1));
+        assertEquals(1, source.size());
+        assertEquals("source", source.key(0));
+        assertEquals(2, source.value(0));
+        assertEquals(10, source.child(0));
+        assertEquals(20, source.child(1));
+        assertEquals(0, target.size());
+        assertEquals(30, target.child(0));
+    }
+
+    @Test
+    public void testInsertPlace() throws IOException {
         for (int i = 1; i <= 26; i++) {
+            MockPager<String, Integer> pager = new MockPager<>(i);
+            BTree<String, Integer> btree = new BTree<>(pager);
+
             var expectedKeys = new ArrayList<>(i);
             var expectedValues = new ArrayList<>(i);
             var expectedChildren = new ArrayList<>(i);
 
-            var nonLeafPage = (MockBTreePage<String, Integer>)pager.create(false);
+            var nonLeafPage = pager.create(false);
             nonLeafPage.child(i, i);
 
             while (nonLeafPage.size() < i) {
@@ -43,7 +124,7 @@ public class BTreeUnitTest {
 
     @Test
     public void testDeletePlace() throws IOException {
-        Pager<BTreePage<String, Integer>> pager = new MockPager<>(26);
+        MockPager<String, Integer> pager = new MockPager<>(26);
         BTree<String, Integer> btree = new BTree<>(pager);
 
         for (int i = 1; i <= 26; i++) {
@@ -51,7 +132,7 @@ public class BTreeUnitTest {
             var expectedValues = new ArrayList<>(i);
             var expectedChildren = new ArrayList<>(i);
 
-            var nonLeafPage = (MockBTreePage<String, Integer>)pager.create(false);
+            var nonLeafPage = pager.create(false);
             nonLeafPage.size(i);
             for (int j = 0; j < i; j++) {
                 nonLeafPage.key(j, String.valueOf((char)('a' + j)));

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
@@ -1,4 +1,106 @@
 package com.github.jambodb.storage.btrees;
 
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Random;
+
 public class BTreeUnitTest {
+    private Random random = new Random();
+
+    @Test
+    public void testInsertPlace() throws IOException {
+        Pager<BTreePage<String, Integer>> pager = new MockPager<>(26);
+        BTree<String, Integer> btree = new BTree<>(pager);
+
+        for (int i = 1; i <= 26; i++) {
+            var expectedKeys = new ArrayList<>(i);
+            var expectedValues = new ArrayList<>(i);
+            var expectedChildren = new ArrayList<>(i);
+
+            var nonLeafPage = (MockBTreePage<String, Integer>)pager.create(false);
+            nonLeafPage.child(i, i);
+
+            while (nonLeafPage.size() < i) {
+                int index = random.nextInt(nonLeafPage.size()+1);
+                btree.insertPlace(nonLeafPage, index);
+
+                nonLeafPage.key(index, String.valueOf((char)('a' + index)));
+                nonLeafPage.value(index, index);
+                nonLeafPage.child(index, index);
+
+                expectedKeys.add(index, nonLeafPage.key(index));
+                expectedValues.add(index, nonLeafPage.value(index));
+                expectedChildren.add(index, nonLeafPage.child(index));
+
+                assertArrayEquals(expectedKeys.toArray(), nonLeafPage.getKeys());
+                assertArrayEquals(expectedValues.toArray(), nonLeafPage.getValues());
+                assertArrayEquals(expectedChildren.toArray(), nonLeafPage.getValues());
+            }
+        }
+    }
+
+    @Test
+    public void testDeletePlace() throws IOException {
+        Pager<BTreePage<String, Integer>> pager = new MockPager<>(26);
+        BTree<String, Integer> btree = new BTree<>(pager);
+
+        for (int i = 1; i <= 26; i++) {
+            var expectedKeys = new ArrayList<>(i);
+            var expectedValues = new ArrayList<>(i);
+            var expectedChildren = new ArrayList<>(i);
+
+            var nonLeafPage = (MockBTreePage<String, Integer>)pager.create(false);
+            nonLeafPage.size(i);
+            for (int j = 0; j < i; j++) {
+                nonLeafPage.key(j, String.valueOf((char)('a' + j)));
+                nonLeafPage.value(j, j);
+                nonLeafPage.child(j, j);
+
+                expectedKeys.add(nonLeafPage.key(j));
+                expectedValues.add(nonLeafPage.value(j));
+                expectedChildren.add(nonLeafPage.child(j));
+            }
+            nonLeafPage.child(i, i);
+            expectedChildren.add(i);
+
+            while (nonLeafPage.size() > 0) {
+                int index = random.nextInt(nonLeafPage.size());
+                btree.deletePlace(nonLeafPage, index);
+                expectedKeys.remove(index);
+                expectedValues.remove(index);
+                expectedChildren.remove(index);
+
+                assertArrayEquals(expectedKeys.toArray(), nonLeafPage.getKeys());
+                assertArrayEquals(expectedValues.toArray(), nonLeafPage.getValues());
+                assertArrayEquals(expectedChildren.toArray(), nonLeafPage.getChildren());
+            }
+        }
+    }
+
+    @Test
+    public void testGetChildPage() throws IOException {
+        Pager<BTreePage<String, Object>> pager = new MockPager<>(3);
+        BTree<String, Object> btree = new BTree<>(pager);
+
+        var leafPage = pager.create(true);
+        leafPage.size(1);
+        var nonLeafPage = pager.create(false);
+        nonLeafPage.size(1);
+
+        nonLeafPage.child(0, 0);
+        var childPage = btree.getChildPage(nonLeafPage, 0);
+        assertEquals(0, childPage.id(), "getChildPage should retrieve page id (0) from the pager");
+
+        nonLeafPage.child(0, 10);
+        childPage = btree.getChildPage(nonLeafPage, 0);
+        assertNull(childPage, "child page for an invalid page id (10) should be null");
+
+        leafPage.child(0, 1);
+        assertTrue(leafPage.isLeaf());
+        assertThrows(IllegalArgumentException.class, () -> btree.getChildPage(leafPage, 0), "getChildPage should throw IllegalArgumentException if called on leaf page");
+        assertThrows(IndexOutOfBoundsException.class, () -> btree.getChildPage(nonLeafPage, 10), "getChildPage should throw IndexOutOfBoundsException if called with and invalid index");
+        assertThrows(IndexOutOfBoundsException.class, () -> btree.getChildPage(nonLeafPage, -1), "getChildPage should throw IndexOutOfBoundsException if called with and invalid index");
+    }
 }

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
@@ -11,6 +11,48 @@ public class BTreeUnitTest {
     private Random random = new Random();
 
     @Test
+    public void testMerge() throws IOException {
+        for (int i = 1; i <= 100; i++) {
+            MockPager<String, Integer> pager = new MockPager<>(i * 2);
+            BTree<String, Integer> btree = new BTree<>(pager);
+
+            var parent = fillWithDummyData(pager.create(false), i);
+            var source = fillWithDummyData(pager.create(false), i);
+            var target = fillWithDummyData(pager.create(false), random.nextInt(i) + 1);
+
+            int index = random.nextInt(parent.size());
+            parent.child(index, target.id());
+            parent.child(index+1, source.id());
+
+            var targetExpectedKeys = new ArrayList<>(Arrays.asList(target.getKeys()));
+            var targetExpectedValues = new ArrayList<>(Arrays.asList(target.getValues()));
+            var targetExpectedChildren = new ArrayList<>(Arrays.asList(target.getChildren()));
+
+            targetExpectedKeys.add(parent.key(index));
+            targetExpectedValues.add(parent.value(index));
+            targetExpectedKeys.addAll(Arrays.asList(source.getKeys()));
+            targetExpectedValues.addAll(Arrays.asList(source.getValues()));
+            targetExpectedChildren.addAll(Arrays.asList(source.getChildren()));
+
+            var parentExpectedKeys = new ArrayList<>(Arrays.asList(parent.getKeys()));
+            var parentExpectedValues = new ArrayList<>(Arrays.asList(parent.getValues()));
+            var parentExpectedChildren = new ArrayList<>(Arrays.asList(parent.getChildren()));
+
+            parentExpectedKeys.remove(index);
+            parentExpectedValues.remove(index);
+            parentExpectedChildren.remove(index+1);
+
+            btree.merge(new BTree.Node<>(parent, index), source, target);
+            assertArrayEquals(parentExpectedKeys.toArray(), parent.getKeys());
+            assertArrayEquals(parentExpectedValues.toArray(), parent.getValues());
+            assertArrayEquals(parentExpectedChildren.toArray(), parent.getChildren());
+            assertArrayEquals(targetExpectedKeys.toArray(), target.getKeys());
+            assertArrayEquals(targetExpectedValues.toArray(), target.getValues());
+            assertArrayEquals(targetExpectedChildren.toArray(), target.getChildren());
+        }
+    }
+
+    @Test
     public void testMove() throws IOException {
         for (int i = 1; i <= 100; i++) {
             MockPager<String, Integer> pager = new MockPager<>(i);

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
@@ -28,14 +28,13 @@ public class BTreeUnitTest {
             var targetExpectedChildren = new ArrayList<>(Arrays.asList(target.getChildren()));
 
             while (source.size() > 0) {
-                target.size(0);
                 int index = random.nextInt(source.size());
 
                 move(sourceExpectedKeys, targetExpectedKeys, index);
                 move(sourceExpectedValues, targetExpectedValues, index);
                 moveChildren(sourceExpectedChildren, targetExpectedChildren, index);
 
-                btree.move(source, index, target);
+                btree.move(source, target, index);
                 assertArrayEquals(sourceExpectedKeys.toArray(), source.getKeys());
                 assertArrayEquals(sourceExpectedValues.toArray(), source.getValues());
                 assertArrayEquals(sourceExpectedChildren.toArray(), source.getChildren());
@@ -47,15 +46,18 @@ public class BTreeUnitTest {
     }
 
     private void moveChildren(ArrayList<Object> source, ArrayList<Object> target, int index) {
-        target.clear();
+        target.remove(target.size() - 1);
         target.addAll(source.subList(index, source.size()));
-        source.removeAll(target.subList(1, target.size()));
+        while (index < source.size() - 1) {
+            source.remove(source.size() - 1);
+        }
     }
 
     private void move(ArrayList<Object> source, ArrayList<Object> target, int index) {
-        target.clear();
         target.addAll(source.subList(index, source.size()));
-        source.removeAll(target);
+        while (index < source.size()) {
+            source.remove(source.size() - 1);
+        }
     }
 
     @Test

--- a/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/BTreeUnitTest.java
@@ -35,7 +35,7 @@ public class BTreeUnitTest {
         var leftPage = fillWithDummyData(pager.create(false), random.nextInt(size) + 1);
 
         parent.child(index, leftPage.id());
-        parent.child(index+1, rightPage.id());
+        parent.child(index + 1, rightPage.id());
 
         var parentExpectedKeys = new ArrayList<>(Arrays.asList(parent.getKeys()));
         var parentExpectedValues = new ArrayList<>(Arrays.asList(parent.getValues()));
@@ -51,9 +51,9 @@ public class BTreeUnitTest {
 
         boolean canBorrow;
 
-        if(borrowRight) {
+        if (borrowRight) {
             canBorrow = rightPage.canBorrow();
-            if(canBorrow) {
+            if (canBorrow) {
                 leftExpectedKeys.add(parentExpectedKeys.get(index));
                 leftExpectedValues.add(parentExpectedValues.get(index));
                 parentExpectedKeys.set(index, rightExpectedKeys.get(0));
@@ -65,10 +65,9 @@ public class BTreeUnitTest {
             }
 
             assertEquals(canBorrow, btree.borrowRight(new BTree.Node<>(parent, index), leftPage));
-        }
-        else {
+        } else {
             canBorrow = leftPage.canBorrow();
-            if(canBorrow) {
+            if (canBorrow) {
                 rightExpectedKeys.add(0, parentExpectedKeys.get(index));
                 rightExpectedValues.add(0, parentExpectedValues.get(index));
                 parentExpectedKeys.set(index, leftExpectedKeys.get(leftExpectedKeys.size() - 1));
@@ -79,7 +78,7 @@ public class BTreeUnitTest {
                 leftExpectedChildren.remove(leftExpectedChildren.size() - 1);
             }
 
-            assertEquals(canBorrow, btree.borrowLeft(new BTree.Node<>(parent, index+1), rightPage));
+            assertEquals(canBorrow, btree.borrowLeft(new BTree.Node<>(parent, index + 1), rightPage));
         }
 
         assertArrayEquals(parentExpectedKeys.toArray(), parent.getKeys());
@@ -116,7 +115,7 @@ public class BTreeUnitTest {
         var leftPage = fillWithDummyData(pager.create(false), random.nextInt(size) + 1);
 
         parent.child(index, leftPage.id());
-        parent.child(index+1, rightPage.id());
+        parent.child(index + 1, rightPage.id());
 
         var targetExpectedKeys = new ArrayList<>(Arrays.asList(leftPage.getKeys()));
         var targetExpectedValues = new ArrayList<>(Arrays.asList(leftPage.getValues()));
@@ -134,13 +133,12 @@ public class BTreeUnitTest {
 
         parentExpectedKeys.remove(index);
         parentExpectedValues.remove(index);
-        parentExpectedChildren.remove(index+1);
+        parentExpectedChildren.remove(index + 1);
 
-        if(mergeRight) {
+        if (mergeRight) {
             btree.mergeRight(new BTree.Node<>(parent, index), leftPage);
-        }
-        else {
-            btree.mergeLeft(new BTree.Node<>(parent, index+1), rightPage);
+        } else {
+            btree.mergeLeft(new BTree.Node<>(parent, index + 1), rightPage);
         }
         assertArrayEquals(parentExpectedKeys.toArray(), parent.getKeys());
         assertArrayEquals(parentExpectedValues.toArray(), parent.getValues());
@@ -311,9 +309,9 @@ public class BTreeUnitTest {
         expectedChildren.add(0, size * 10);
 
         while (expectedKeys.size() < size) {
-            int index = random.nextInt(nonLeafPage.size()+1);
+            int index = random.nextInt(nonLeafPage.size() + 1);
 
-            String key = String.valueOf((char)('a' + index));
+            String key = String.valueOf((char) ('a' + index));
             int value = index + 1;
             int child = index * 10;
 
@@ -353,7 +351,7 @@ public class BTreeUnitTest {
         var nonLeafPage = pager.create(false);
         nonLeafPage.size(size);
         for (int j = 0; j < size; j++) {
-            nonLeafPage.key(j, String.valueOf((char)('a' + j)));
+            nonLeafPage.key(j, String.valueOf((char) ('a' + j)));
             nonLeafPage.value(j, j);
             nonLeafPage.child(j, j);
 
@@ -404,7 +402,7 @@ public class BTreeUnitTest {
 
     private MockBTreePage<String, Integer> fillWithDummyData(MockBTreePage<String, Integer> page, int size) {
         page.size(size);
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             page.key(i, "k" + i);
             page.value(i, i * 100);
             page.child(i, i * 10);

--- a/src/test/java/com/github/jambodb/storage/btrees/MockBTreePage.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/MockBTreePage.java
@@ -44,17 +44,7 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
             throw new IllegalArgumentException("invalid size " + size);
         }
         this.size = size;
-    }
-
-    @Override
-    public void clean() {
-        for(int i = size + 1; i < children.length; i++) {
-            children[i] = -1;
-        }
-        for(int i = size; i < keys.length; i++) {
-            keys[i] = null;
-            values[i] = null;
-        }
+        clean();
     }
 
     @Override
@@ -134,5 +124,15 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
             result[i] = array[i];
         }
         return result;
+    }
+
+    private void clean() {
+        for(int i = size + 1; i < children.length; i++) {
+            children[i] = -1;
+        }
+        for(int i = size; i < keys.length; i++) {
+            keys[i] = null;
+            values[i] = null;
+        }
     }
 }

--- a/src/test/java/com/github/jambodb/storage/btrees/MockBTreePage.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/MockBTreePage.java
@@ -89,4 +89,9 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
     public void child(int index, int child) {
         children[index] = child;
     }
+
+    @Override
+    public String toString() {
+        return "page:" + id;
+    }
 }

--- a/src/test/java/com/github/jambodb/storage/btrees/MockBTreePage.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/MockBTreePage.java
@@ -22,9 +22,9 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
         this.id = id;
         this.maxDegree = maxDegree;
         this.leaf = leaf;
-        keys = new Object[maxDegree+1];
-        values = new Object[maxDegree+1];
-        children = new int[maxDegree+2];
+        keys = new Object[maxDegree + 1];
+        values = new Object[maxDegree + 1];
+        children = new int[maxDegree + 2];
         Arrays.fill(children, -1);
     }
 
@@ -40,7 +40,7 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
 
     @Override
     public void size(int size) {
-        if(size < 0) {
+        if (size < 0) {
             throw new IllegalArgumentException("invalid size " + size);
         }
         this.size = size;
@@ -69,7 +69,7 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
 
     @Override
     public K key(int index) {
-        return (K)keys[index];
+        return (K) keys[index];
     }
 
     @Override
@@ -79,7 +79,7 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
 
     @Override
     public V value(int index) {
-        return (V)values[index];
+        return (V) values[index];
     }
 
     @Override
@@ -111,8 +111,8 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
     }
 
     public Object[] getChildren() {
-        Object[] result = new Object[size+1];
-        for(int i = 0; i < result.length; i++) {
+        Object[] result = new Object[size + 1];
+        for (int i = 0; i < result.length; i++) {
             result[i] = children[i];
         }
         return result;
@@ -120,17 +120,17 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
 
     private Object[] getCleared(Object[] array) {
         Object[] result = new Object[size];
-        for(int i = 0; i < result.length; i++) {
+        for (int i = 0; i < result.length; i++) {
             result[i] = array[i];
         }
         return result;
     }
 
     private void clean() {
-        for(int i = size + 1; i < children.length; i++) {
+        for (int i = size + 1; i < children.length; i++) {
             children[i] = -1;
         }
-        for(int i = size; i < keys.length; i++) {
+        for (int i = size; i < keys.length; i++) {
             keys[i] = null;
             values[i] = null;
         }

--- a/src/test/java/com/github/jambodb/storage/btrees/MockBTreePage.java
+++ b/src/test/java/com/github/jambodb/storage/btrees/MockBTreePage.java
@@ -1,5 +1,7 @@
 package com.github.jambodb.storage.btrees;
 
+import java.util.Arrays;
+
 public class MockBTreePage<K, V> implements BTreePage<K, V> {
 
     private int id;
@@ -23,6 +25,7 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
         keys = new Object[maxDegree+1];
         values = new Object[maxDegree+1];
         children = new int[maxDegree+2];
+        Arrays.fill(children, -1);
     }
 
     @Override
@@ -37,7 +40,21 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
 
     @Override
     public void size(int size) {
+        if(size < 0) {
+            throw new IllegalArgumentException("invalid size " + size);
+        }
         this.size = size;
+    }
+
+    @Override
+    public void clean() {
+        for(int i = size + 1; i < children.length; i++) {
+            children[i] = -1;
+        }
+        for(int i = size; i < keys.length; i++) {
+            keys[i] = null;
+            values[i] = null;
+        }
     }
 
     @Override
@@ -93,5 +110,29 @@ public class MockBTreePage<K, V> implements BTreePage<K, V> {
     @Override
     public String toString() {
         return "page:" + id;
+    }
+
+    public Object[] getKeys() {
+        return getCleared(keys);
+    }
+
+    public Object[] getValues() {
+        return getCleared(values);
+    }
+
+    public Object[] getChildren() {
+        Object[] result = new Object[size+1];
+        for(int i = 0; i < result.length; i++) {
+            result[i] = children[i];
+        }
+        return result;
+    }
+
+    private Object[] getCleared(Object[] array) {
+        Object[] result = new Object[size];
+        for(int i = 0; i < result.length; i++) {
+            result[i] = array[i];
+        }
+        return result;
     }
 }


### PR DESCRIPTION
This PR fixes the methods that perform a query on the BTree, which had a bug that did not allow it to find the correct first key a given query, It also improves the test for the BTree adding unit tests to some basic methods and improving the functional test.